### PR TITLE
Dagger mod use should override previous versions

### DIFF
--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -149,21 +149,21 @@ var moduleUseCmd = &cobra.Command{
 				return fmt.Errorf("failed to get module config: %w", err)
 			}
 
-			depSet := make(map[string]struct{})
-			for _, dep := range modCfg.Dependencies {
-				depSet[dep] = struct{}{}
-			}
-			for _, newDep := range extraArgs {
-				depMod, err := resolver.ResolveModuleDependency(ctx, engineClient.Dagger(), modFlagCfg.Module, newDep)
+			var deps []string
+			deps = append(deps, modCfg.Dependencies...)
+			deps = append(deps, extraArgs...)
+			depSet := make(map[string]*resolver.Module)
+			for _, dep := range deps {
+				depMod, err := resolver.ResolveModuleDependency(ctx, engineClient.Dagger(), modFlagCfg.Module, dep)
 				if err != nil {
 					return fmt.Errorf("failed to get module: %w", err)
 				}
-				depSet[depMod.String()] = struct{}{}
+				depSet[depMod.Path] = depMod
 			}
 
 			modCfg.Dependencies = nil
-			for dep := range depSet {
-				modCfg.Dependencies = append(modCfg.Dependencies, dep)
+			for _, dep := range depSet {
+				modCfg.Dependencies = append(modCfg.Dependencies, dep.String())
 			}
 			sort.Strings(modCfg.Dependencies)
 


### PR DESCRIPTION
Previously, dagger mod use would allow creating multiple versions of a single module:

	{
	  "root": "",
	  "name": "foo",
	  "sdk": "go",
	  "dependencies": [
	    "github.com/<example>/daggerverse@aaa"
	    "github.com/<example>/daggerverse@bbb"
	  ]
	}

To prevent this, we can resolve all the dependencies, and then use the dependency set based on only the path instead of the combination of path and version.