### PR TITLE
fix: Exclude currentSelection tool when environment is empty

### DIFF
--- a/core/env.go
+++ b/core/env.go
@@ -128,6 +128,10 @@ func (env *Env) Types() []string {
 	return types
 }
 
+func (env *Env) IsEmpty() bool {
+	return len(env.objsByName) == 0
+}
+
 type Binding struct {
 	Key         string
 	Value       dagql.Typed


### PR DESCRIPTION
Previously, the currentSelection tool was always included in the builtins, even when the environment was empty

This commit modifies the Builtins function to conditionally append the currentSelection tool only when the environment contains valid object bindings (i.e., when !m.env.IsEmpty())